### PR TITLE
Updating end year, exception for missing years

### DIFF
--- a/cps_stage1/stage1.py
+++ b/cps_stage1/stage1.py
@@ -6,7 +6,7 @@ CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 
 def main(syr=2014):
     SYR = str(syr)  # Start year of CPS
-    EYR = 2031  # Last year in our extrapolation
+    EYR = 2032  # Last year in our extrapolation
 
     # Read in state SOI estimates
     soi_estimates = pd.read_csv(

--- a/cps_stage2/solver.jl
+++ b/cps_stage2/solver.jl
@@ -80,7 +80,7 @@ function Solve_func(year, tol)
 
 end
 
-year_list = [x for x in 2014:2031]
+year_list = [x for x in 2014:2032]
 tol = 0.70
 
 # Run solver function for all years and tolerances (in order)

--- a/cps_stage2/stage2.py
+++ b/cps_stage2/stage2.py
@@ -62,12 +62,15 @@ def main():
     # write .npz input files for solver
     skipped_years = []
     for year in range(START_YEAR, END_YEAR + 1):
-        factor_match = _factors[year].equals(CUR_FACTORS[year])
-        target_match = stage_2_targets[f"{year}"].equals(CUR_TARGETS[f"{year}"])
-        if files_match and factor_match and target_match:
-            print(f"Skipping {year}")
-            skipped_years.append(year)
-            continue
+        try:
+            factor_match = _factors[year].equals(CUR_FACTORS[year])
+            target_match = stage_2_targets[f"{year}"].equals(CUR_TARGETS[f"{year}"])
+            if files_match and factor_match and target_match:
+                print(f"Skipping {year}")
+                skipped_years.append(year)
+                continue
+        except KeyError:
+            pass
         dataprep(cps, stage_1_factors, stage_2_targets, year)
 
     # Solver (in Julia)


### PR DESCRIPTION
This PR accomplishes two tasks:
1. It updates the end year in `stage1.py` and `solver.jl`
2. Uses a `try` to get around a `KeyError` that is raised when trying to reads existing weights for years that are not in the existing weights file.